### PR TITLE
read_lines should output list(type) by contract but did set(type)

### DIFF
--- a/Fred2/IO/FileReader.py
+++ b/Fred2/IO/FileReader.py
@@ -101,7 +101,7 @@ def read_lines(files, type=Peptide):
                 collect.add(type(line.strip().upper()))
 
 
-    return collect
+    return list(collect)
 
 
 #####################################


### PR DESCRIPTION
FIXED: read_lines should output list(type) by contract but did set(type)