### PR TITLE
Hotfix/read line output type error

### DIFF
--- a/Fred2/IO/FileReader.py
+++ b/Fred2/IO/FileReader.py
@@ -101,7 +101,7 @@ def read_lines(files, type=Peptide):
                 collect.add(type(line.strip().upper()))
 
 
-    return collect
+    return list(collect)
 
 
 #####################################

--- a/Fred2/IO/FileReader.py
+++ b/Fred2/IO/FileReader.py
@@ -60,7 +60,7 @@ def read_fasta(files, type=Peptide, id_position=1):
                     collect.add(type(seq.strip().upper(), _transcript_id=_id))
                 except TypeError:
                     collect.add(type(seq.strip().upper()))
-    return collect
+    return list(collect)
 
 
 


### PR DESCRIPTION
read_lines and read_fasta should return list(type) but did set(type)