### PR TITLE
Optional parameters for external prediction methods

### DIFF
--- a/Fred2/CleavagePrediction/External.py
+++ b/Fred2/CleavagePrediction/External.py
@@ -9,6 +9,7 @@
 """
 
 import sys
+import os
 import subprocess
 import pandas
 
@@ -27,7 +28,7 @@ class NetChop_3_1(ACleavageSitePrediction, AExternal):
     __supported_length = [sys.maxint]
     __name = "netchop"
     __cleavage_pos = 0
-    __command = "netChop %s | grep -v '#' > %s"
+    __command = "netChop {input} {options} | grep -v '#' > {out}"
     __version = "3.1"
 
     @property
@@ -53,25 +54,47 @@ class NetChop_3_1(ACleavageSitePrediction, AExternal):
     def predict(self, _aa_seq, **kwargs):
 
         if isinstance(_aa_seq, Peptide) or isinstance(_aa_seq, Protein):
-            pep_seqs = {str(_aa_seq):_aa_seq}
+            pep_seqs = {str(_aa_seq): _aa_seq}
         else:
             if any((not isinstance(p, Peptide)) and (not isinstance(p, Protein)) for p in _aa_seq):
                 raise ValueError("Input is not of type Protein or Peptide")
-            pep_seqs = {str(p):p for p in _aa_seq}
+            pep_seqs = {str(p): p for p in _aa_seq}
 
         tmp_out = NamedTemporaryFile(delete=False)
         tmp_file = NamedTemporaryFile(delete=False)
         tmp_file.write("\n".join(">pep_%i\n%s"%(i, str(p)) for i, p in enumerate(pep_seqs.iterkeys())))
         tmp_file.close()
 
-        r = subprocess.call(self.command%(tmp_file.name, tmp_out.name), shell=True)
-        if r == 127:
-                raise RuntimeError("%s is not installed or globally executable."%self.name)
-        elif r != 0:
-                raise RuntimeError("An unknown error occurred for method %s. "
-                                   "Please check whether %s is globally executable."%(self.name, self.name))
+        #allowe customary executable specification
+        if "path" in kwargs:
+            exe = self.command.split()[0]
+            _command = self.command.replace(exe, kwargs["path"])
+        else:
+            _command = self.command
 
-        return self.parse_external_result(tmp_out)
+        try:
+            stdo = None
+            stde = None
+            cmd = _command.format(peptides=tmp_file.name, options=kwargs.get("options", ""), out=tmp_out.name)
+            p = subprocess.Popen(cmd, shell=True, stdin=subprocess.PIPE, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
+            p.wait() #block the rest
+            stdo, stde = p.communicate()
+            stdr = p.returncode
+            if stdr > 0:
+                raise RuntimeError("Unsuccessful execution of " + cmd + " (EXIT!=0) with error: " + stde)
+        except Exception as e:
+            raise RuntimeError(e)
+
+        result = self.parse_external_result(tmp_out)
+
+        df_result = CleavageSitePredictionResult.from_dict(result)
+        df_result.index = pandas.MultiIndex.from_tuples([tuple((i,j)) for i, j in df_result.index],
+                                                        names=['ID', 'Pos'])
+        os.remove(tmp_file.name)
+        tmp_out.close()
+        os.remove(tmp_out.name)
+
+        return df_result
 
     def parse_external_result(self, _file):
         result = {"Seq": {}, self.name: {}}
@@ -96,10 +119,8 @@ class NetChop_3_1(ACleavageSitePrediction, AExternal):
                 seq_id = "seq_%i"%count
                 result["Seq"][(seq_id, pos)] = aa
                 result[self.name][(seq_id, pos)] = float(s)
-        df_result = CleavageSitePredictionResult.from_dict(result)
-        df_result.index = pandas.MultiIndex.from_tuples([tuple((i,j)) for i, j in df_result.index],
-                                                        names=['ID', 'Pos'])
-        return df_result
+
+        return result
 
     def get_external_version(self):
         #cannot be determined method does not support --version or something similar

--- a/Fred2/EpitopePrediction/External.py
+++ b/Fred2/EpitopePrediction/External.py
@@ -65,6 +65,14 @@ class AExternalEpitopePrediction(AEpitopePrediction, AExternal):
 
         #group alleles in blocks of 80 alleles (NetMHC can't deal with more)
         _MAX_ALLELES = 50
+
+        #allowe customary executable specification
+        if "path" in kwargs:
+            exe = self.command.split()[0]
+            _command = self.command.replace(exe, kwargs["path"])
+        else:
+            _command = self.command
+
         allele_groups = []
         c_a = 0
         allele_group = []
@@ -105,7 +113,8 @@ class AExternalEpitopePrediction(AEpitopePrediction, AExternal):
                 try:
                     stdo = None
                     stde = None
-                    cmd = self.command.format(peptides=tmp_file.name, alleles=",".join(allele_group), out=tmp_out.name)
+                    cmd = _command.format(peptides=tmp_file.name, alleles=",".join(allele_group),
+                                          options=kwargs.get("options", ""), out=tmp_out.name)
                     p = subprocess.Popen(cmd, shell=True, stdin=subprocess.PIPE, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
                     p.wait() #block the rest
                     stdo, stde = p.communicate()
@@ -150,7 +159,7 @@ class NetMHC_3_4(AExternalEpitopePrediction):
                            'C*07:02', 'C*08:02', 'C*12:03', 'C*14:02', 'C*15:02', 'E*01:01'])
     __supported_length = frozenset([8, 9, 10, 11])
     __name = "netmhc"
-    __command = "netMHC -p {peptides} -a {alleles} -x {out}"
+    __command = "netMHC -p {peptides} -a {alleles} -x {out} {options}"
     __version = "3.4"
 
     @property
@@ -205,9 +214,9 @@ class NetMHCpan_2_4(AExternalEpitopePrediction):
 
         Supported  MHC alleles currently only restricted to HLA alleles
     """
-    __supported_length = frozenset([8,9,10,11])
+    __supported_length = frozenset([8, 9, 10, 11])
     __name = "netmhcpan"
-    __command = "netMHCpan -p {peptides} -a {alleles} -ic50 -xls -xlsfile {out}"
+    __command = "netMHCpan -p {peptides} -a {alleles} {options} -ic50 -xls -xlsfile {out}"
     __alleles = frozenset(['A*01:01', 'A*01:02', 'A*01:03', 'A*01:06', 'A*01:07', 'A*01:08', 'A*01:09', 'A*01:10', 'A*01:12',
                  'A*01:13', 'A*01:14', 'A*01:17', 'A*01:19', 'A*01:20', 'A*01:21', 'A*01:23', 'A*01:24', 'A*01:25',
                  'A*01:26', 'A*01:28', 'A*01:29', 'A*01:30', 'A*01:32', 'A*01:33', 'A*01:35', 'A*01:36', 'A*01:37',
@@ -591,7 +600,7 @@ class NetMHCII_2_2(AExternalEpitopePrediction,AExternal):
     """
     __supported_length = frozenset([15])
     __name = "netmhcII"
-    __command = 'netMHCII {peptides} -a {alleles} | grep -v "#" > {out}'
+    __command = 'netMHCII {peptides} -a {alleles} {options} | grep -v "#" > {out}'
     __alleles = frozenset(
         ['DRB1*01:01', 'DRB1*03:01', 'DRB1*04:01', 'DRB1*04:04', 'DRB1*04:05', 'DRB1*07:01', 'DRB1*08:02', 'DRB1*09:01',
          'DRB1*11:01', 'DRB1*13:02', 'DRB1*15:01', 'DRB3*01:01', 'DRB4*01:01', 'DRB5*01:01'])
@@ -646,9 +655,9 @@ class NetMHCIIpan_3_0(AExternalEpitopePrediction,AExternal):
         Implements a wrapper for NetMHCIIpan
     """
 
-    __supported_length = frozenset([8,9,10,11,12,13,14,15,16,17,18,19,20])
+    __supported_length = frozenset([8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20])
     __name = "netmchIIpan"
-    __command = "netMHCIIpan -f {peptides} -inptype 1 -a {alleles} -xls -xlsfile {out}"
+    __command = "netMHCIIpan -f {peptides} -inptype 1 -a {alleles} {options} -xls -xlsfile {out}"
     __alleles = frozenset(['DRB1*01:01', 'DRB1*01:02', 'DRB1*01:03', 'DRB1*01:04', 'DRB1*01:05', 'DRB1*01:06', 'DRB1*01:07',
                  'DRB1*01:08', 'DRB1*01:09', 'DRB1*01:10', 'DRB1*01:11', 'DRB1*01:12', 'DRB1*01:13', 'DRB1*01:14',
                  'DRB1*01:15', 'DRB1*01:16', 'DRB1*01:17', 'DRB1*01:18', 'DRB1*01:19', 'DRB1*01:20', 'DRB1*01:21',
@@ -796,8 +805,8 @@ class PickPocket_1_1(AExternalEpitopePrediction):
 
     """
     __name = "pickpocket"
-    __supported_length = frozenset([8,9,10,11])
-    __command = 'PickPocket -p {peptides} -a {alleles} | grep -v "#" > {out}'
+    __supported_length = frozenset([8, 9, 10, 11])
+    __command = 'PickPocket -p {peptides} -a {alleles} {options} | grep -v "#" > {out}'
     __supported_alleles = frozenset(['A*01:01', 'A*01:02', 'A*01:03', 'A*01:06', 'A*01:07', 'A*01:08', 'A*01:09',
         'A*01:10', 'A*01:12', 'A*01:13', 'A*01:14', 'A*01:17', 'A*01:19', 'A*01:20', 'A*01:21', 'A*01:23', 'A*01:24',
         'A*01:25', 'A*01:26', 'A*01:28', 'A*01:29', 'A*01:30', 'A*01:32', 'A*01:33', 'A*01:35', 'A*01:36', 'A*01:37',
@@ -1129,7 +1138,7 @@ class PickPocket_1_1(AExternalEpitopePrediction):
                     continue
                 else:
                     s = row.split()
-                    result[s[1].replace("*","")][s[2]] = float(s[4])
+                    result[s[1].replace("*", "")][s[2]] = float(s[4])
         return result
 
     def get_external_version(self):

--- a/Fred2/test/external/TestExternalCleavagePrediction.py
+++ b/Fred2/test/external/TestExternalCleavagePrediction.py
@@ -1,6 +1,7 @@
 __author__ = 'schubert'
 
 import unittest
+import os
 
 from Fred2.Core import Peptide
 from Fred2.Core import Protein
@@ -29,7 +30,15 @@ class TestExternalCleavagePredictonClass(unittest.TestCase):
             mo = CleavageSitePredictorFactory("NetChop")
             mo.predict(self.seqs[0])
 
-
+    def test_path_option_and_optionl_parameters(self):
+        netchop = CleavageSitePredictorFactory("NetChop")
+        exe = netchop.command.split()[0]
+        for try_path in os.environ["PATH"].split(os.pathsep):
+            try_path = try_path.strip('"')
+            exe_try = os.path.join(try_path, exe).strip()
+            if os.path.isfile(exe_try) and os.access(exe_try, os.X_OK):
+                print exe_try
+                netchop.predict(self.seqs, path=exe_try, options="-v 1")
 
 if __name__ == '__main__':
     unittest.main()

--- a/Fred2/test/external/TestExternalEpitopePrediction.py
+++ b/Fred2/test/external/TestExternalEpitopePrediction.py
@@ -2,9 +2,8 @@
 Unittest for external epitope prediction methods
 """
 
-
-
 import unittest
+import os
 
 from Fred2.Core import Allele
 from Fred2.Core import Peptide
@@ -71,7 +70,17 @@ class TestExternalEpitopePredictionClass(unittest.TestCase):
 
     def test_wrong_internal_to_external_version(self):
         with self.assertRaises(RuntimeError):
-            EpitopePredictorFactory("NetMHC", version="3.0").predict(self.mhcI, alleles=self.transcript)
+            EpitopePredictorFactory("NetMHC", version="3.0").predict(self.peptides_mhcI, alleles=self.mhcI)
+
+    def test_path_option_and_optionl_parameters(self):
+        netmhc = EpitopePredictorFactory("NetMHC")
+        exe = netmhc.command.split()[0]
+        for try_path in os.environ["PATH"].split(os.pathsep):
+            try_path = try_path.strip('"')
+            exe_try = os.path.join(try_path, exe).strip()
+            if os.path.isfile(exe_try) and os.access(exe_try, os.X_OK):
+                print exe_try
+                netmhc.predict(self.peptides_mhcI, alleles=self.mhcI, path=exe_try, options="--sort")
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
* specification of explicit executable via path="/path/to/exec"
* specification of optional parameters via options="-s some  -v options"
  * options are not checked for support and directly included in command line call