### PR TITLE
fix/SVM_prediction peptide sanity check

### DIFF
--- a/Fred2/EpitopePrediction/SVM.py
+++ b/Fred2/EpitopePrediction/SVM.py
@@ -44,9 +44,11 @@ class ASVMEpitopePrediction(AEpitopePrediction, ASVM):
         if isinstance(peptides, Peptide):
             pep_seqs = {str(peptides): peptides}
         else:
-            if any(not isinstance(p, Peptide) for p in peptides):
-                raise ValueError("Input is not of type Protein or Peptide")
-            pep_seqs = {str(p): p for p in peptides}
+            pep_seqs = {}
+            for p in peptides:
+                if not isinstance(p, Peptide):
+                    raise ValueError("Input is not of type Protein or Peptide")
+                pep_seqs[str(p)] = p
 
         if alleles is None:
             al = [Allele("HLA-" + a) for a in self.supportedAlleles]


### PR DESCRIPTION
Sanity check iterated fully over the input peptides which resulted in an empty iterator for the rest of the prediction algorithm