### PR TITLE
[FIX] NetChop IDs, TAP peptide grouping

### DIFF
--- a/Fred2/TAPPrediction/PSSM.py
+++ b/Fred2/TAPPrediction/PSSM.py
@@ -149,7 +149,9 @@ class SMMTAP(APSSMTAPPrediction):
                 pep_seqs[str(p)] = p
 
         result = {self.name: {}}
-        for length, peps in itertools.groupby(pep_seqs.iterkeys(), key=lambda x: len(x)):
+        pep_groups = pep_seqs.keys()
+        pep_groups.sort(key=len)
+        for length, peps in itertools.groupby(pep_groups, key=len):
             if length < 9:
                 warnings.warn("No model found for %s with length %i"%(self.name, length))
                 continue


### PR DESCRIPTION
NetChop can have arbitrary long Protein IDs now

PSSM-TAP correctly groups peptides based on length 