### PR TITLE
Change mysql dependency to PyMySQL

### DIFF
--- a/Fred2/IO/MartsAdapter.py
+++ b/Fred2/IO/MartsAdapter.py
@@ -11,7 +11,7 @@ import csv
 import urllib2
 import warnings
 import logging
-import MySQLdb
+import pymysql.cursors
 from operator import itemgetter
 
 from Fred2.IO.ADBAdapter import ADBAdapter, EAdapterFields, EIdentifierTypes
@@ -32,7 +32,7 @@ co
         self.sequence_proxy = dict()
 
         if usr and host and pwd and db:
-            self.connection = MySQLdb.connect(user=usr, host=host, passwd=pwd, db=db)
+            self.connection = pymysql.connect(user=usr, host=host, password=pwd, db=db)
         else:
             self.connection = None
 

--- a/setup.py
+++ b/setup.py
@@ -120,6 +120,6 @@ setup(
     #ext_modules=[d2s_module],
 
     # Run-time dependencies. (will be installed by pip when FRED2 is installed)
-    install_requires=['setuptools>=18.2', 'pandas', 'pyomo>=4.0','svmlight', 'MySQL-python >= 1.2.4', 'biopython', 'pyVCF'],
+    install_requires=['setuptools>=18.2', 'pandas', 'pyomo>=4.0','svmlight', 'PyMySQL', 'biopython', 'pyVCF'],
 
 )


### PR DESCRIPTION
Change mysql dependency to PyMySQL.

Import and connect function in `MartsAdapter.py` have been adapted accordingly. The dependency (PyMySQL) has been added to `setup.py`.