### PR TITLE
Use last python2 compatible versions for PyMySQL and biopython

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -120,6 +120,6 @@ setup(
     #ext_modules=[d2s_module],
 
     # Run-time dependencies. (will be installed by pip when FRED2 is installed)
-    install_requires=['setuptools>=18.2', 'pandas', 'pyomo>=4.0','svmlight', 'PyMySQL==0.10.1', 'biopython', 'pyVCF', 'mhcflurry<=1.4.3', 'mhcnuggets'],
+    install_requires=['setuptools>=18.2', 'pandas', 'pyomo>=4.0','svmlight', 'PyMySQL==0.10.1', 'biopython=1.76', 'pyVCF', 'mhcflurry<=1.4.3', 'mhcnuggets'],
 
 )

--- a/setup.py
+++ b/setup.py
@@ -120,6 +120,6 @@ setup(
     #ext_modules=[d2s_module],
 
     # Run-time dependencies. (will be installed by pip when FRED2 is installed)
-    install_requires=['setuptools>=18.2', 'pandas', 'pyomo>=4.0','svmlight', 'PyMySQL==0.10.1', 'biopython=1.76', 'pyVCF', 'mhcflurry<=1.4.3', 'mhcnuggets'],
+    install_requires=['setuptools>=18.2', 'pandas', 'pyomo>=4.0','svmlight', 'PyMySQL==0.10.1', 'biopython==1.76', 'pyVCF', 'mhcflurry<=1.4.3', 'mhcnuggets'],
 
 )

--- a/setup.py
+++ b/setup.py
@@ -120,6 +120,6 @@ setup(
     #ext_modules=[d2s_module],
 
     # Run-time dependencies. (will be installed by pip when FRED2 is installed)
-    install_requires=['setuptools>=18.2', 'pandas', 'pyomo>=4.0','svmlight', 'PyMySQL', 'biopython', 'pyVCF', 'mhcflurry<=1.4.3', 'mhcnuggets'],
+    install_requires=['setuptools>=18.2', 'pandas', 'pyomo>=4.0','svmlight', 'PyMySQL==0.10.1', 'biopython', 'pyVCF', 'mhcflurry<=1.4.3', 'mhcnuggets'],
 
 )


### PR DESCRIPTION
FRED2 requires several dependencies which are installed in the `setup.py` script. Specific versions are not set for all packages and thus the latest version (presumbly) is installed of the dependency. The latest versions of PyMySQL and biopython are no longer compatible with Python2. 

This PR sets the versions of PyMySQL and biopython to the last version that is compatible with Python2. Without setting these versions the installation of FRED2 will fail.